### PR TITLE
Consolidate some SnappyRouter methods

### DIFF
--- a/src/Vectorface/SnappyRouter/SnappyRouter.php
+++ b/src/Vectorface/SnappyRouter/SnappyRouter.php
@@ -89,16 +89,6 @@ class SnappyRouter
     }
 
     /**
-     * Backwards compatibility wrapper. Handles routing for CLI requests.
-     * @param array $components Command-line arguments.
-     * @return string Returns the response string.
-     */
-    public function handleCliRoute($components)
-    {
-        return $this->invokeHandler(true, array($components));
-    }
-
-    /**
      * Determines which handler is appropriate for this request.
      *
      * @param bool $isCli True for CLI handlers, false otherwise.


### PR DESCRIPTION
By trusting internal functions to call methods with correctly structured arguments, some duplicated code can be removed. handleHttpRoute and handleCliRoute were consolidated down to invokeHandler, and determineHttpHandler and determineCliHandler consolidated down to determineHandler.

In order to maintain compatibility with unit tests without exposing the private method, the handleHttpRoute method is left in place as a wrapper for invokeHandler.
