### PR TITLE
Support phpdbg SAPI as a command-line environment.

### DIFF
--- a/src/Vectorface/SnappyRouter/SnappyRouter.php
+++ b/src/Vectorface/SnappyRouter/SnappyRouter.php
@@ -60,6 +60,7 @@ class SnappyRouter
 
         switch ($environment) {
             case 'cli':
+            case 'phpdbg':
                 $components = empty($_SERVER['argv']) ? array() : $_SERVER['argv'];
                 return $this->handleCliRoute($components).PHP_EOL;
             default:


### PR DESCRIPTION
This is a pretty trivial change to add support for the phpdbg SAPI alongside the vanilla cli SAPI.

phpdbg support should make it easier to debug router-based tests. The change should be completely backwards compatible and does not affect unit test coverage (still 100%).