### PR TITLE
Update to allow DELETE and PUT methods in Cross Origin Plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 coverage/
 site/
 vendor/
+.idea

--- a/src/Vectorface/SnappyRouter/Plugin/AccessControl/CrossOriginRequestPlugin.php
+++ b/src/Vectorface/SnappyRouter/Plugin/AccessControl/CrossOriginRequestPlugin.php
@@ -48,7 +48,7 @@ class CrossOriginRequestPlugin extends AbstractPlugin
 
     // the array of allowed HTTP verbs that can be used to perform cross origin requests
     private static $allowedMethods = array(
-        'GET', 'POST', 'OPTIONS'
+        'GET', 'POST', 'OPTIONS','DELETE','PUT'
     );
 
     /**


### PR DESCRIPTION
Trying to use PUT or DELETE methods would fail as they are not in the allowed methods array.

Added them in.