### PR TITLE
Add support for an input stream to HttpRequest.

### DIFF
--- a/src/Vectorface/SnappyRouter/Handler/ControllerHandler.php
+++ b/src/Vectorface/SnappyRouter/Handler/ControllerHandler.php
@@ -94,8 +94,10 @@ class ControllerHandler extends PatternMatchHandler
         $this->request = new HttpRequest(
             ucfirst($controller).'Controller',
             $action.'Action',
-            $verb
+            $verb,
+            'php://stdin'
         );
+
         $this->request->setQuery($query);
         $this->request->setPost($post);
 

--- a/src/Vectorface/SnappyRouter/Request/HttpRequest.php
+++ b/src/Vectorface/SnappyRouter/Request/HttpRequest.php
@@ -53,7 +53,7 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
         $this->input = array(
             self::INPUT_METHOD_QUERY  => array(),
             self::INPUT_METHOD_POST   => array(),
-            self::INPUT_METHOD_BODY => null
+            self::INPUT_METHOD_BODY   => null
         );
     }
 

--- a/src/Vectorface/SnappyRouter/Request/HttpRequest.php
+++ b/src/Vectorface/SnappyRouter/Request/HttpRequest.php
@@ -17,7 +17,7 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
     /** Holds the contents of the various inputs ($_GET, $_POST, etc) */
     private $input;
 
-    /** The input stream */
+    /** The input stream (stream or location string) */
     private $stream;
 
     /** Array key for query parameters */
@@ -179,7 +179,7 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
 
         if (is_resource($this->stream) && 'stream' === get_resource_type($this->stream)) {
             $streamData = stream_get_contents($this->stream);
-        } else if (is_string($this->stream)) {
+        } elseif (is_string($this->stream)) {
             $stream = @fopen($this->stream, "r");
 
             if (false === $stream) {

--- a/src/Vectorface/SnappyRouter/Request/HttpRequest.php
+++ b/src/Vectorface/SnappyRouter/Request/HttpRequest.php
@@ -24,8 +24,8 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
     const INPUT_METHOD_QUERY = 'QUERY';
     /** Array key for post parameters */
     const INPUT_METHOD_POST = 'POST';
-    /** Array key for input stream */
-    const INPUT_METHOD_STREAM = 'STREAM';
+    /** Array key for input stream body */
+    const INPUT_METHOD_BODY = 'BODY';
 
     // mappings between magic filter strings and the filter functions
     private static $filterCallbacks = array(
@@ -44,7 +44,7 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
      * @param string $verb The HTTP verb used in the request.
      * @param mixed $stream A stream or a string describing a stream location.
      */
-    public function __construct($controller, $action, $verb, $stream)
+    public function __construct($controller, $action, $verb, $stream = 'php://input')
     {
         parent::__construct($controller, $action);
         $this->setVerb($verb);
@@ -53,7 +53,7 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
         $this->input = array(
             self::INPUT_METHOD_QUERY  => array(),
             self::INPUT_METHOD_POST   => array(),
-            self::INPUT_METHOD_STREAM => ''
+            self::INPUT_METHOD_BODY => null
         );
     }
 
@@ -170,11 +170,11 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
      * Returns the input stream data for the current request
      * @return string The input stream data
      */
-    public function getInputStream()
+    public function getBody()
     {
         // If this value has been read from the stream, retrieve it from storage
-        if (!empty($this->input[self::INPUT_METHOD_STREAM])) {
-            return $this->input[self::INPUT_METHOD_STREAM];
+        if (null !== $this->input[self::INPUT_METHOD_BODY]) {
+            return $this->input[self::INPUT_METHOD_BODY];
         }
 
         if (is_resource($this->stream) && 'stream' === get_resource_type($this->stream)) {
@@ -197,9 +197,9 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
             throw new InternalErrorException('Unable to open request input stream.');
         }
 
-        $this->input[self::INPUT_METHOD_STREAM] = $streamData;
+        $this->input[self::INPUT_METHOD_BODY] = $streamData;
 
-        return $this->input[self::INPUT_METHOD_STREAM];
+        return $this->input[self::INPUT_METHOD_BODY];
     }
 
     /**

--- a/src/Vectorface/SnappyRouter/Request/HttpRequest.php
+++ b/src/Vectorface/SnappyRouter/Request/HttpRequest.php
@@ -2,6 +2,8 @@
 
 namespace Vectorface\SnappyRouter\Request;
 
+use Vectorface\SnappyRouter\Exception\InternalErrorException;
+
 /**
  * A class representing an controller-modelled web request.
  * @copyright Copyright (c) 2014, VectorFace, Inc.
@@ -15,10 +17,15 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
     /** Holds the contents of the various inputs ($_GET, $_POST, etc) */
     private $input;
 
+    /** The input stream */
+    private $stream;
+
     /** Array key for query parameters */
     const INPUT_METHOD_QUERY = 'QUERY';
     /** Array key for post parameters */
     const INPUT_METHOD_POST = 'POST';
+    /** Array key for input stream */
+    const INPUT_METHOD_STREAM = 'STREAM';
 
     // mappings between magic filter strings and the filter functions
     private static $filterCallbacks = array(
@@ -35,14 +42,18 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
      * @param string $controller The controller being requested.
      * @param string $action The action being invoked.
      * @param string $verb The HTTP verb used in the request.
+     * @param mixed $stream A stream or a string describing a stream location.
      */
-    public function __construct($controller, $action, $verb)
+    public function __construct($controller, $action, $verb, $stream)
     {
         parent::__construct($controller, $action);
         $this->setVerb($verb);
+        $this->setStream($stream);
+
         $this->input = array(
             self::INPUT_METHOD_QUERY  => array(),
-            self::INPUT_METHOD_POST   => array()
+            self::INPUT_METHOD_POST   => array(),
+            self::INPUT_METHOD_STREAM => ''
         );
     }
 
@@ -63,6 +74,17 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
     public function setVerb($verb)
     {
         $this->verb = $verb;
+        return $this;
+    }
+
+    /**
+     * Sets the stream used in the request.
+     * @param mixed $stream The stream used in the request.
+     * @return RequestInterface Returns $this.
+     */
+    public function setStream($stream)
+    {
+        $this->stream = $stream;
         return $this;
     }
 
@@ -142,6 +164,42 @@ class HttpRequest extends AbstractRequest implements HttpRequestInterface
     {
         $this->input[self::INPUT_METHOD_POST] = (array)$postData;
         return $this;
+    }
+
+    /**
+     * Returns the input stream data for the current request
+     * @return string The input stream data
+     */
+    public function getInputStream()
+    {
+        // If this value has been read from the stream, retrieve it from storage
+        if (!empty($this->input[self::INPUT_METHOD_STREAM])) {
+            return $this->input[self::INPUT_METHOD_STREAM];
+        }
+
+        if (is_resource($this->stream) && 'stream' === get_resource_type($this->stream)) {
+            $streamData = stream_get_contents($this->stream);
+        } else if (is_string($this->stream)) {
+            $stream = @fopen($this->stream, "r");
+
+            if (false === $stream) {
+                throw new InternalErrorException('Unable to open request input stream.');
+            }
+
+            $streamData = stream_get_contents($stream);
+
+            fclose($stream);
+        } else {
+            $streamData = false;
+        }
+
+        if (false === $streamData) {
+            throw new InternalErrorException('Unable to open request input stream.');
+        }
+
+        $this->input[self::INPUT_METHOD_STREAM] = $streamData;
+
+        return $this->input[self::INPUT_METHOD_STREAM];
     }
 
     /**

--- a/src/Vectorface/SnappyRouter/Request/JsonRpcRequest.php
+++ b/src/Vectorface/SnappyRouter/Request/JsonRpcRequest.php
@@ -33,7 +33,7 @@ class JsonRpcRequest extends HttpRequest
         if (is_object($payload) && isset($payload->method)) {
             $action = $payload->method;
         }
-        parent::__construct($controller, $action, $verb);
+        parent::__construct($controller, $action, $verb, 'php://input');
         $this->payload = $payload;
     }
 

--- a/tests/Vectorface/SnappyRouterTests/Request/HttpRequestTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Request/HttpRequestTest.php
@@ -52,15 +52,15 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
 
         /* Mock a stream in memory */
         $request = new HttpRequest('TestService', 'TestMethod', 'GET', $tempStream);
-        $this->assertEquals("test", $request->getInputStream());
+        $this->assertEquals("test", $request->getBody());
         fclose($tempStream);
 
         /* Fetch previously stored value */
-        $this->assertEquals("test", $request->getInputStream());
+        $this->assertEquals("test", $request->getBody());
 
         /* Specify php://memory as a string */
         $request = new HttpRequest('TestService', 'TestMethod', 'GET', 'php://memory');
-        $this->assertEquals("", $request->getInputStream());
+        $this->assertEquals("", $request->getBody());
     }
 
     /**
@@ -70,7 +70,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
     public function testInputStreamIncorrectTypeFailure()
     {
         $request = new HttpRequest('TestService', 'TestMethod', 'GET', 1);
-        $request->getInputStream();
+        $request->getBody();
     }
 
     /**
@@ -80,7 +80,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
     public function testInputStreamIncorrectFileFailure()
     {
         $request = new HttpRequest('TestService', 'TestMethod', 'GET', 'file');
-        $request->getInputStream();
+        $request->getBody();
     }
 
     /**

--- a/tests/Vectorface/SnappyRouterTests/Request/HttpRequestTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Request/HttpRequestTest.php
@@ -4,7 +4,6 @@ namespace Vectorface\SnappyRouterTests\Request;
 
 use \PHPUnit_Framework_TestCase;
 use Vectorface\SnappyRouter\Request\HttpRequest;
-//use Vectorface\SnappyRouter\Exception\InternalErrorException;
 
 /**
  * Tests the HttpRequest class.


### PR DESCRIPTION
This adds basic support for an input stream to HttpRequest (specifically php://input in ControllerHandler), so we can fetch the input stream idiomatically from the request in the controller.

The implementation allows you to provide a stream, or a location, so it can be easily mocked in tests.

Code/test coverage is complete for this implementation.