### PR TITLE
Allow RestHandler to Use Encoders Other Than JsonEncoder.

### DIFF
--- a/src/Vectorface/SnappyRouter/Handler/RestHandler.php
+++ b/src/Vectorface/SnappyRouter/Handler/RestHandler.php
@@ -45,16 +45,11 @@ class RestHandler extends ControllerHandler
         if ($routeInfo[1] & self::MATCHES_ID) {
             $this->routeParams[] = intval($routeInfo[2]['objectId']);
         }
-        return true;
-    }
 
-    /**
-     * Returns the active response encoder.
-     * @return EncoderInterface Returns the response encoder.
-     */
-    public function getEncoder()
-    {
-        return new JsonEncoder();
+        // use JSON encoder by default
+        $this->encoder = new JsonEncoder();
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Adjust RestHandler to not simply return a new instance of JsonEncoder() when asked in getEncoder(), but actually use its local handler pointer as designed in ControllerHandler().