### PR TITLE
Travis-CI config: Add PHP 7.1 and move 5.3 build to older Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,21 @@ sudo: false
 cache: bundler
 
 php:
+  - 7.1
   - 7.0
   - 5.6
   - 5.5
   - 5.4
-  - 5.3
   - hhvm
 
 matrix:
   allow_failures:
     - php: hhvm
   fast_finish: true
+  include:
+    - php: 5.3
+      dist: precise
+
 
 before_script:
   - composer self-update


### PR DESCRIPTION
There are two trivial changes to the travis CI config in this MR:
 - PHP 7.1 added to the build
 - PHP 5.3 configured to run from Ubuntu Precise rather than Trusty; Travis doesn't support 5.3 on Trusty any longer.