### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,13 +14,17 @@
         }
     ],
     "autoload": {
-        "psr-0": {
-            "Vectorface\\SnappyRouter": "./src",
-            "Vectorface\\SnappyRouterTests": "./tests"
+        "psr-4": {
+            "Vectorface\\SnappyRouter\\": "./src/Vectorface/SnappyRouter"
         },
         "files": [
             "./src/Vectorface/SnappyRouter/php-5.3-compat.php"
         ]
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Vectorface\\SnappyRouterTests\\": "./tests/Vectorface/SnappyRouterTests"
+        }
     },
     "homepage": "https://github.com/Vectorface/snappy-router",
     "support": {

--- a/src/Vectorface/SnappyRouter/Plugin/AbstractControllerPlugin.php
+++ b/src/Vectorface/SnappyRouter/Plugin/AbstractControllerPlugin.php
@@ -22,7 +22,6 @@ abstract class AbstractControllerPlugin extends AbstractPlugin implements Contro
         AbstractHandler $handler,
         HttpRequest $request
     ) {
-
     }
 
     /**
@@ -38,7 +37,6 @@ abstract class AbstractControllerPlugin extends AbstractPlugin implements Contro
         AbstractController $controller,
         $action
     ) {
-
     }
 
     /**
@@ -54,7 +52,6 @@ abstract class AbstractControllerPlugin extends AbstractPlugin implements Contro
         AbstractController $controller,
         $action
     ) {
-
     }
 
     /**
@@ -72,6 +69,5 @@ abstract class AbstractControllerPlugin extends AbstractPlugin implements Contro
         $action,
         $response
     ) {
-
     }
 }

--- a/src/Vectorface/SnappyRouter/Plugin/AbstractPlugin.php
+++ b/src/Vectorface/SnappyRouter/Plugin/AbstractPlugin.php
@@ -48,7 +48,6 @@ abstract class AbstractPlugin implements PluginInterface, DiProviderInterface
      */
     public function afterHandlerSelected(AbstractHandler $handler)
     {
-
     }
 
     /**
@@ -57,7 +56,6 @@ abstract class AbstractPlugin implements PluginInterface, DiProviderInterface
      */
     public function afterFullRouteInvoked(AbstractHandler $handler)
     {
-
     }
 
     /**
@@ -67,7 +65,6 @@ abstract class AbstractPlugin implements PluginInterface, DiProviderInterface
      */
     public function errorOccurred(AbstractHandler $handler, Exception $exception)
     {
-
     }
 
     /**

--- a/src/Vectorface/SnappyRouter/SnappyRouter.php
+++ b/src/Vectorface/SnappyRouter/SnappyRouter.php
@@ -185,7 +185,6 @@ class SnappyRouter
             \Vectorface\SnappyRouter\http_response_code($responseCode);
         }
         return $exception->getMessage();
-
     }
 
     /**

--- a/tests/Vectorface/SnappyRouterTests/Authentication/CallbackAuthenticatorTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Authentication/CallbackAuthenticatorTest.php
@@ -2,10 +2,10 @@
 
 namespace Vectorface\SnappyRouterTests\Authentication;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Authentication\CallbackAuthenticator;
 
-class CallbackAuthenticatorTest extends PHPUnit_Framework_TestCase
+class CallbackAuthenticatorTest extends TestCase
 {
     /**
      * A basic test showing standard functionality.

--- a/tests/Vectorface/SnappyRouterTests/Config/ConfigTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Config/ConfigTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Config;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Config\Config;
 
 /**
@@ -10,7 +10,7 @@ use Vectorface\SnappyRouter\Config\Config;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class ConfigTest extends PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     /**
      * Demonstrates basic usage of the Config wrapper class.

--- a/tests/Vectorface/SnappyRouterTests/Controller/TestDummyController.php
+++ b/tests/Vectorface/SnappyRouterTests/Controller/TestDummyController.php
@@ -16,7 +16,6 @@ class TestDummyController extends AbstractController
 
     public function indexAction()
     {
-
     }
 
     public function testAction()

--- a/tests/Vectorface/SnappyRouterTests/Di/DiTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Di/DiTest.php
@@ -2,10 +2,10 @@
 
 namespace Vectorface\SnappyRouterTests\Di;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Di\Di;
 
-class DiTest extends PHPUnit_Framework_TestCase
+class DiTest extends TestCase
 {
     /**
      * Tests the standard set/get methods of the DI.

--- a/tests/Vectorface/SnappyRouterTests/Di/ServiceProviderTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Di/ServiceProviderTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Di;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Di\ServiceProvider;
 
 /**
@@ -10,7 +10,7 @@ use Vectorface\SnappyRouter\Di\ServiceProvider;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class ServiceProviderTest extends PHPUnit_Framework_TestCase
+class ServiceProviderTest extends TestCase
 {
     /**
      * An overview of how to use the ServiceProvider class.

--- a/tests/Vectorface/SnappyRouterTests/Encoder/AbstractEncoderTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Encoder/AbstractEncoderTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Encoder;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Response\Response;
 
 /**
@@ -10,7 +10,7 @@ use Vectorface\SnappyRouter\Response\Response;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-abstract class AbstractEncoderTest extends PHPUnit_Framework_TestCase
+abstract class AbstractEncoderTest extends TestCase
 {
     /**
      * Tests the encode method of the encoder.

--- a/tests/Vectorface/SnappyRouterTests/Exception/InternalErrorExceptionTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Exception/InternalErrorExceptionTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Exception;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Exception\InternalErrorException;
 
 /**
@@ -10,7 +10,7 @@ use Vectorface\SnappyRouter\Exception\InternalErrorException;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class InternalErrorExceptionTest extends \PHPUnit_Framework_TestCase
+class InternalErrorExceptionTest extends TestCase
 {
     /**
      * An overview of how to use the exception.

--- a/tests/Vectorface/SnappyRouterTests/Exception/MethodNotAllowedExceptionTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Exception/MethodNotAllowedExceptionTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Exception;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Exception\MethodNotAllowedException;
 
 /**
@@ -10,7 +10,7 @@ use Vectorface\SnappyRouter\Exception\MethodNotAllowedException;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class MethodNotAllowedExceptionTest extends PHPUnit_Framework_TestCase
+class MethodNotAllowedExceptionTest extends TestCase
 {
     /**
      * An overview of how the class works.

--- a/tests/Vectorface/SnappyRouterTests/Handler/ControllerHandlerTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Handler/ControllerHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Handler;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\SnappyRouter;
 use Vectorface\SnappyRouter\Config\Config;
 use Vectorface\SnappyRouter\Encoder\NullEncoder;
@@ -13,7 +13,7 @@ use Vectorface\SnappyRouter\Handler\ControllerHandler;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class ControllerHandlerTest extends PHPUnit_Framework_TestCase
+class ControllerHandlerTest extends TestCase
 {
     /**
      * An overview of how to use the ControllerHandler.

--- a/tests/Vectorface/SnappyRouterTests/Handler/DirectScriptHandlerTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Handler/DirectScriptHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Handler;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Handler\DirectScriptHandler;
 
 /**
@@ -10,7 +10,7 @@ use Vectorface\SnappyRouter\Handler\DirectScriptHandler;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class DirectScriptHandlerTest extends PHPUnit_Framework_TestCase
+class DirectScriptHandlerTest extends TestCase
 {
     /**
      * An overview of how to use the class.

--- a/tests/Vectorface/SnappyRouterTests/Handler/JsonRpcHandlerTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Handler/JsonRpcHandlerTest.php
@@ -4,7 +4,7 @@ namespace Vectorface\SnappyRouterTests\Handler;
 
 use \Exception;
 use \ReflectionClass;
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Config\Config;
 use Vectorface\SnappyRouter\Handler\JsonRpcHandler;
 
@@ -13,7 +13,7 @@ use Vectorface\SnappyRouter\Handler\JsonRpcHandler;
  *
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  */
-class JsonRpcHandlerTest extends PHPUnit_Framework_TestCase
+class JsonRpcHandlerTest extends TestCase
 {
     /**
      * Helper method to override the internals of php://input for test purposes.
@@ -62,10 +62,10 @@ class JsonRpcHandlerTest extends PHPUnit_Framework_TestCase
             array('jsonrpc' => '2.0', 'method' => 'testAction', 'id' => '2')
         ));
         $this->assertTrue($handler->isAppropriate('/x/y/z/TestController', array(), array(), 'POST'));
-        $this->assertEquals(2, count($handler->getRequests()));
+        $this->assertCount(2, $handler->getRequests());
 
         $result = json_decode($handler->performRoute());
-        $this->assertEquals(2, count($result), "Expect 2 responses for 2 calls");
+        $this->assertCount(2, $result, "Expect 2 responses for 2 calls");
         $this->assertEquals("2.0", $result[0]->jsonrpc);
         $this->assertEquals("This is a test service.", $result[0]->result);
         $this->assertEquals("1", $result[0]->id);
@@ -80,7 +80,7 @@ class JsonRpcHandlerTest extends PHPUnit_Framework_TestCase
         ));
         $this->assertTrue($handler->isAppropriate('/x/y/z/TestController', array(), array(), 'POST'));
         $result = json_decode($handler->performRoute());
-        $this->assertEquals(1, count($result), "Expect 1 response for 1 call and 1 notification");
+        $this->assertCount(1, $result, "Expect 1 response for 1 call and 1 notification");
         $this->assertEquals("1", $result[0]->id);
     }
 
@@ -111,7 +111,6 @@ class JsonRpcHandlerTest extends PHPUnit_Framework_TestCase
         $handler = new JsonRpcHandler($options);
         $this->setRequestPayload($handler, array());
         $this->assertTrue($handler->isAppropriate("/x////y//z/Test/TestController.php", array(), array(), 'POST'));
-
     }
 
     /**

--- a/tests/Vectorface/SnappyRouterTests/Handler/PatternMatchHandlerTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Handler/PatternMatchHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Handler;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Handler\PatternMatchHandler;
 
 /**
@@ -10,7 +10,7 @@ use Vectorface\SnappyRouter\Handler\PatternMatchHandler;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class PatternMatchHandlerTest extends PHPUnit_Framework_TestCase
+class PatternMatchHandlerTest extends TestCase
 {
     /**
      * Demonstrates how to use the PatternMatchHandler class.

--- a/tests/Vectorface/SnappyRouterTests/Handler/RestHandlerTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Handler/RestHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Handler;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Config\Config;
 use Vectorface\SnappyRouter\Handler\RestHandler;
 
@@ -11,7 +11,7 @@ use Vectorface\SnappyRouter\Handler\RestHandler;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class RestHandlerTest extends PHPUnit_Framework_TestCase
+class RestHandlerTest extends TestCase
 {
     /**
      * An overview of how to use the RestHandler class.

--- a/tests/Vectorface/SnappyRouterTests/PhpFivePointThreeCompatTest.php
+++ b/tests/Vectorface/SnappyRouterTests/PhpFivePointThreeCompatTest.php
@@ -2,10 +2,10 @@
 
 namespace Vectorface\SnappyRouterTests;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Di\Di;
 
-class PhpFivePointThreeCompatTest extends PHPUnit_Framework_TestCase
+class PhpFivePointThreeCompatTest extends TestCase
 {
     public function testHttpResponseCode()
     {

--- a/tests/Vectorface/SnappyRouterTests/Plugin/AccessControl/CrossOriginRequestPluginTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Plugin/AccessControl/CrossOriginRequestPluginTest.php
@@ -2,15 +2,13 @@
 
 namespace Vectorface\SnappyRouterTests\Plugin\AccessControl;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Exception\AccessDeniedException;
 use Vectorface\SnappyRouter\Exception\InternalErrorException;
 use Vectorface\SnappyRouter\Handler\ControllerHandler;
 use Vectorface\SnappyRouter\Handler\PatternMatchHandler;
 use Vectorface\SnappyRouter\Handler\JsonRpcHandler;
 use Vectorface\SnappyRouter\Plugin\AccessControl\CrossOriginRequestPlugin;
-use Vectorface\SnappyRouter\Request\HttpRequest;
-use Vectorface\SnappyRouterTests\Controller\TestDummyController;
 use Vectorface\SnappyRouterTests\Handler\JsonRpcHandlerTest;
 
 /**
@@ -18,7 +16,7 @@ use Vectorface\SnappyRouterTests\Handler\JsonRpcHandlerTest;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class CrossOriginRequestPluginTest extends PHPUnit_Framework_TestCase
+class CrossOriginRequestPluginTest extends TestCase
 {
     /**
      * An overview of how to use the plugin.
@@ -194,7 +192,6 @@ class CrossOriginRequestPluginTest extends PHPUnit_Framework_TestCase
         } catch (AccessDeniedException $e) {
             $this->fail('Cross origin plugin should not have denied access.');
         }
-
     }
 
     /**
@@ -225,6 +222,5 @@ class CrossOriginRequestPluginTest extends PHPUnit_Framework_TestCase
         } catch (AccessDeniedException $e) {
             $this->fail('Cross origin plugin should not have denied access.');
         }
-
     }
 }

--- a/tests/Vectorface/SnappyRouterTests/Plugin/Authentication/AbstractAuthenticationPluginTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Plugin/Authentication/AbstractAuthenticationPluginTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Plugin\Authentication;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 use Vectorface\SnappyRouter\Authentication\CallbackAuthenticator;
 use Vectorface\SnappyRouter\Di\Di;
@@ -17,7 +17,7 @@ use Vectorface\SnappyRouter\Handler\ControllerHandler;
  * @author J. Anderson <janderson@vectorface.com>
  * @author Dan Bruce   <dbruce@vectorface.com>
  */
-class AbstractAuthenticationPluginTest extends PHPUnit_Framework_TestCase
+class AbstractAuthenticationPluginTest extends TestCase
 {
     /**
      * Authentication of service requests happens by intercepting preInvoke; Validate that.

--- a/tests/Vectorface/SnappyRouterTests/Plugin/Authentication/HttpBasicAuthenticationPluginTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Plugin/Authentication/HttpBasicAuthenticationPluginTest.php
@@ -2,7 +2,7 @@
 
 namespace casino\Tests\engine\ServiceRouter\Plugin\Authentication;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Authentication\CallbackAuthenticator;
 use Vectorface\SnappyRouter\Di\Di;
 use Vectorface\SnappyRouter\Exception\InternalErrorException;
@@ -16,7 +16,7 @@ use Vectorface\SnappyRouter\Plugin\Authentication\HttpBasicAuthenticationPlugin;
  * @author J. Anderson <janderson@vectorface.com>
  * @author Dan Bruce   <dbruce@vectorface.com>
  */
-class HttpBasicAuthenticationPluginTest extends PHPUnit_Framework_TestCase
+class HttpBasicAuthenticationPluginTest extends TestCase
 {
     /**
      * Test the HTTPBasicAuthenticationPlugin; All in one test!

--- a/tests/Vectorface/SnappyRouterTests/Plugin/HttpHeader/RouterHeaderPluginTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Plugin/HttpHeader/RouterHeaderPluginTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Plugin\HttpHeader;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Handler\ControllerHandler;
 use Vectorface\SnappyRouter\Plugin\HttpHeader\RouterHeaderPlugin;
 
@@ -11,7 +11,7 @@ use Vectorface\SnappyRouter\Plugin\HttpHeader\RouterHeaderPlugin;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class RouterHeaderPluginTest extends PHPUnit_Framework_TestCase
+class RouterHeaderPluginTest extends TestCase
 {
     /**
      * An overview of how to use the plugin.

--- a/tests/Vectorface/SnappyRouterTests/Plugin/TestPluginTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Plugin/TestPluginTest.php
@@ -2,11 +2,10 @@
 
 namespace Vectorface\SnappyRouterTests\Plugin;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Plugin\AbstractPlugin;
-use Vectorface\SnappyRouter\Plugin\PluginInterface;
 
-class TestPluginTest extends PHPUnit_Framework_TestCase
+class TestPluginTest extends TestCase
 {
     /**
      * A demonstrate of a simple test plugin.

--- a/tests/Vectorface/SnappyRouterTests/Request/HttpRequestTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Request/HttpRequestTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Request;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Request\HttpRequest;
 
 /**
@@ -10,7 +10,7 @@ use Vectorface\SnappyRouter\Request\HttpRequest;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class HttpRequestTest extends PHPUnit_Framework_TestCase
+class HttpRequestTest extends TestCase
 {
     /**
      * An overview of how to use the RPCRequest class.
@@ -25,8 +25,9 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('POST', $request->setVerb('POST')->getVerb());
 
         $queryData = array('id' => '1234');
-        $this->assertTrue(
-            1234 === $request->setQuery($queryData)->getQuery('id', 0, 'int')
+        $this->assertSame(
+            1234,
+            $request->setQuery($queryData)->getQuery('id', 0, 'int')
         );
 
         $postData = array('username' => ' TEST_USER ');
@@ -91,7 +92,7 @@ class HttpRequestTest extends PHPUnit_Framework_TestCase
     {
         $request = new HttpRequest('TestService', 'TestMethod', 'GET', 'php://input');
         $request->setQuery(array('key' => $value));
-        $this->assertTrue($expected === $request->getQuery('key', null, $filters));
+        $this->assertSame($expected, $request->getQuery('key', null, $filters));
     }
 
     /**

--- a/tests/Vectorface/SnappyRouterTests/Request/JsonRpcRequestTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Request/JsonRpcRequestTest.php
@@ -2,6 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Request;
 
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Request\JsonRpcRequest;
 
 /**
@@ -9,7 +10,7 @@ use Vectorface\SnappyRouter\Request\JsonRpcRequest;
  *
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  */
-class JsonRpcRequestTest extends \PHPUnit_Framework_TestCase
+class JsonRpcRequestTest extends TestCase
 {
     /**
      * An overview of how to use the JsonRpcRequest class.

--- a/tests/Vectorface/SnappyRouterTests/Response/JsonRpcResponseTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Response/JsonRpcResponseTest.php
@@ -2,16 +2,17 @@
 
 namespace Vectorface\SnappyRouterTests\Response;
 
-use \Exception;
-use \Vectorface\SnappyRouter\Request\JsonRpcRequest;
-use \Vectorface\SnappyRouter\Response\JsonRpcResponse;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Vectorface\SnappyRouter\Request\JsonRpcRequest;
+use Vectorface\SnappyRouter\Response\JsonRpcResponse;
 
 /**
  * Tests the JsonRpcResponse class.
  *
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  */
-class JsonRpcResponseTest extends \PHPUnit_Framework_TestCase
+class JsonRpcResponseTest extends TestCase
 {
     /**
      * An overview of how to use the JsonRpcResponse class.
@@ -44,6 +45,5 @@ class JsonRpcResponseTest extends \PHPUnit_Framework_TestCase
         $obj = $response->getResponseObject();
         $this->assertEquals(123, $obj->error->code);
         $this->assertEquals("ex", $obj->error->message);
-
     }
 }

--- a/tests/Vectorface/SnappyRouterTests/SnappyRouterTest.php
+++ b/tests/Vectorface/SnappyRouterTests/SnappyRouterTest.php
@@ -9,14 +9,14 @@ use Vectorface\SnappyRouter\Plugin\PluginInterface;
 use Vectorface\SnappyRouter\Handler\AbstractHandler;
 use Vectorface\SnappyRouter\Handler\ControllerHandler;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Tests the main SnappyRouter class.
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class SnappyRouterTest extends PHPUnit_Framework_TestCase
+class SnappyRouterTest extends TestCase
 {
     /**
      * Returns a standard router config array.

--- a/tests/Vectorface/SnappyRouterTests/Task/CliTaskHandlerTest.php
+++ b/tests/Vectorface/SnappyRouterTests/Task/CliTaskHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Task;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Vectorface\SnappyRouter\Config\Config;
 use Vectorface\SnappyRouter\Handler\CliTaskHandler;
 
@@ -11,7 +11,7 @@ use Vectorface\SnappyRouter\Handler\CliTaskHandler;
  * @copyright Copyright (c) 2014, VectorFace, Inc.
  * @author Dan Bruce <dbruce@vectorface.com>
  */
-class CliTaskHandlerTest extends PHPUnit_Framework_TestCase
+class CliTaskHandlerTest extends TestCase
 {
     /**
      * An overview of how to use the CliTaskHandler class.

--- a/tests/Vectorface/SnappyRouterTests/Task/DummyTestTask.php
+++ b/tests/Vectorface/SnappyRouterTests/Task/DummyTestTask.php
@@ -2,7 +2,7 @@
 
 namespace Vectorface\SnappyRouterTests\Task;
 
-use \Exception;
+use Exception;
 use Vectorface\SnappyRouter\Task\AbstractTask;
 
 class DummyTestTask extends AbstractTask

--- a/tests/test_global_function_overrides.php
+++ b/tests/test_global_function_overrides.php
@@ -10,7 +10,7 @@ function function_exists($class)
 
     if (in_array($class, $blacklist)) {
         return false;
-    } else {
-        return \function_exists($class);
     }
+
+    return \function_exists($class);
 }


### PR DESCRIPTION
# Changed log
- Using the class-based PHPUnit namespace to be compatible with latest PHPUnit version.
- The `psr-0` autoloading is deprecated and using the `psr-4` autoloading instead.
- Using the `assertCount` to check whether the expected count is same as result.
- Using the `assertSame` to check the expected is same as result strictly.