### PR TITLE
Fix for empty base path causing warnings

### DIFF
--- a/src/Vectorface/SnappyRouter/Handler/ControllerHandler.php
+++ b/src/Vectorface/SnappyRouter/Handler/ControllerHandler.php
@@ -158,7 +158,7 @@ class ControllerHandler extends PatternMatchHandler
      */
     protected function extractPathFromBasePath($path, $options)
     {
-        if (isset($options[self::KEY_BASE_PATH])) {
+        if (!empty($options[self::KEY_BASE_PATH])) {
             $pos = strpos($path, $options[self::KEY_BASE_PATH]);
             if (false !== $pos) {
                 $path = substr($path, $pos + strlen($options[self::KEY_BASE_PATH]));


### PR DESCRIPTION
We've been seeing warnings like these:

```
PHP Warning:  strpos(): Empty needle in /vendor/vectorface/snappy-router/src/Vectorface/SnappyRouter/Handler/ControllerHandler.php on line 162
```

If the needle is an empty string, we should skip this code path.